### PR TITLE
Avoid extraneous whitespace.

### DIFF
--- a/ftplugin/python/python.xpt.vim
+++ b/ftplugin/python/python.xpt.vim
@@ -38,16 +38,16 @@ XPTvar $SPfun      ''
 " for ( ** statement ** )
 " [ ** a, b ** ]
 " { ** 'k' : 'v' ** }
-XPTvar $SParg      ' '
+XPTvar $SParg      ''
 
 " if ** (
 " while ** (
 " for ** (
-XPTvar $SPcmd      ' '
+XPTvar $SPcmd      ''
 
 " a ** = ** a ** + ** 1
 " (a, ** b, ** )
-XPTvar $SPop       ' '
+XPTvar $SPop       ''
 
 
 


### PR DESCRIPTION
http://www.python.org/dev/peps/pep-0008/#whitespace-in-expressions-and-s
tatements
