### PR TITLE
HTML 5 should be the default expansion for html

### DIFF
--- a/ftplugin/html/html.xpt.vim
+++ b/ftplugin/html/html.xpt.vim
@@ -202,7 +202,7 @@ XSET doctype|post=html_doctype_post( V() )
 
 
 XPT html " <html><head>..<head><body>...
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<!DOCTYPE html>
 <html>
     `:head:^
     <body>


### PR DESCRIPTION
Right now, the default doctype for the HTML expansion is:

```
<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
```

Which is obsolete. Instead, it should default to the new and much simpler HTML 5 doctype:

```
<!DOCTYPE html>
```