### PR TITLE
Modify the outdated xpt perl template. This new template uses best pr…

### DIFF
--- a/ftplugin/perl/perl.xpt.vim
+++ b/ftplugin/perl/perl.xpt.vim
@@ -44,6 +44,10 @@ XPT fornn hidden=1
 
 XPT whilenn hidden=1
 
+" Not perl's way of doing things
+XPT while1 hidden=1
+XPT while0 hidden=1
+
 
 XPT perl " #!/usr/bin/env perl
 #!/usr/bin/env perl
@@ -54,24 +58,20 @@ use warnings;
 
 ..XPT
 
-
 XPT iif " .. if ..;
-`expr^ if `cond^;
+if`$SPcmd^(`$SParg^`condition^`$SParg^)`$BRif^{{
+	`cursor^
+}}
 
 XPT wwhen " .. when ..;
-`expr^ when `cond^;
-
-XPT wwhile " .. while ..;
-`expr^ while `cond^;
-
+when`$SPcmd^(`$SParg^m/`regex^/`$SParg^)`$BRif^{{
+	`cursor^
+}}
 
 XPT uunless " .. unless ..;
-`expr^ unless `cond^;
-
-
-XPT fforeach " .. foreach ..;
-`expr^ foreach `list^;
-
+unless`$SPcmd^(`$SParg^`condition^`$SParg^)`$BRif^{{
+	`cursor^
+}}
 
 XPT sub " sub .. { .. }
 sub `fun_name^`$BRfun^{
@@ -102,7 +102,7 @@ sub (`arg*^) {
 }
 
 XPT proto " sub .. ();
-sub `fun_name^ (`proto^)
+sub `fun_name^ (`proto^);
 
 XPT unless " unless ( .. ) { .. }
 unless`$SPcmd^(`$SParg^`cond^`$SParg^)`$BRif^{
@@ -151,15 +151,41 @@ continue`$BRif^{
 	`job^
 }
 
-XPT whileeach " while \( \( key, val ) = each\( %** ) )
-while`$SPcmd^(`$SParg^(`$SParg^$`key^,`$SPop^$`val^`$SParg^) = each(`$SParg^%`array^`$SParg^)`$SParg^)`$BRloop^{
+XPT while " while \( \$line = <FILE>  )
+while`$SPcmd^(`$SParg^`condition^`$SParg^)`$BRloop^{
+	`cursor^
+}
+`continue...{{^`Include:_continue^`}}^
+
+XPT while " while \( .. ) { .. }
+while`$SPcmd^(`$SParg^`condition^`$SParg^)`$BRloop^{
+	`cursor^
+}
+`continue...{{^`Include:_continue^`}}^
+
+XPT until " until \( ... ) { .. }
+until`$SPcmd^(`$SParg^`condition^`$SParg^)`$BRloop^{
+	`cursor^
+}
+`continue...{{^`Include:_continue^`}}^
+
+XPT _while hidden
+`$BRloop^`while^ `condition^
+
+XPT do wrap " do { .. } while ( .. )
+do`$BRloop^{
+    `cursor^
+}`loop...{{^`Include:_while^`}}^;
+
+XPT whileeach " while \( my \( key, val ) = hash )
+while`$SPcmd^(`$SParg^my (`$SParg^$`key^,`$SPop^$`val^`$SParg^) = `hash^`$SParg^)`$BRloop^{
 	`cursor^
 }
 `continue...{{^`Include:_continue^`}}^
 
 
-XPT whileline " while \( \$line = <FILE>  )
-while`$SPcmd^(`$SParg^$`line^`$SPop^=`$SPop^<`STDIN^>`$SParg^)`$BRloop^{
+XPT whileline " while \( my \$line = <FILE>  )
+while`$SPcmd^(`$SParg^my $`line^`$SPop^=`$SPop^<`STDIN^>`$SParg^)`$BRloop^{
 	`cursor^
 }
 `continue...{{^`Include:_continue^`}}^
@@ -209,10 +235,10 @@ XSET elts=c_printf_elts( R( 'pattern' ), ',' )
 "`pattern^"`elts^
 
 XPT printf	" printf\(...)
-printf `$SParg^`:_printfElts:^`$SParg^
+printf `:_printfElts:^
 
 XPT sprintf	" sprintf\(...)
-sprintf `$SParg^`:_printfElts:^`$SParg^
+sprintf `:_printfElts:^
 
 XPT _if hidden
 if`$SPcmd^(`$SParg^`condition^`$SParg^)`$BRif^{
@@ -235,7 +261,7 @@ XPT ifee		" if (..) { .. } else if...
 `else...{{^`Include:else^`}}^
 
 XPT _when hidden
-when`$SPcmd^(`$SParg^$`var^`$SParg^)`$BRif^{
+when`$SPcmd^(`$SParg^m/`regex^/`$SParg^)`$BRif^{
     `cursor^
 }
 
@@ -248,8 +274,8 @@ XPT when " when (..) { .. } ...
 `:_when:^` `when...{{^`$BRel^`Include:_when^``when...^`}}^
 `default...{{^`Include:_default^`}}^
 
-XPT given wrap=job " given ( .. ) { .. }
-given`$SPcmd^(`$SParg^m/`regx^/^`$SParg^)`$BRif^{
+XPT given wrap=var " given ( .. ) { .. }
+given`$SPcmd^(`$SParg^$`var^^`$SParg^)`$BRif^{
 	`cursor^
 }
 

--- a/ftplugin/perl/perl.xpt.vim
+++ b/ftplugin/perl/perl.xpt.vim
@@ -58,17 +58,17 @@ use warnings;
 
 ..XPT
 
-XPT iif " .. if ..;
+XPT iff " if \( .. ) {{ .. }}
 if`$SPcmd^(`$SParg^`condition^`$SParg^)`$BRif^{{
 	`cursor^
 }}
 
-XPT wwhen " .. when ..;
+XPT whenn " when \( .. ) {{ .. }}
 when`$SPcmd^(`$SParg^m/`regex^/`$SParg^)`$BRif^{{
 	`cursor^
 }}
 
-XPT uunless " .. unless ..;
+XPT unlesss " unless \( .. ) {{ .. }}
 unless`$SPcmd^(`$SParg^`condition^`$SParg^)`$BRif^{{
 	`cursor^
 }}
@@ -78,33 +78,33 @@ sub `fun_name^`$BRfun^{
 	`cursor^
 }
 
-XPT ssub " sub .. ( .. ) { .. }
+XPT subsigna " sub .. \( .. ) { .. }
 XSET arg*|post=ExpandIfNotEmpty(', ', 'arg*')
 sub `fun_name^(`$SParg^`arg*^`$SParg^)`$BRfun^{
 	`cursor^
 }
 
-XPT psub " sub :prototype( .. ) ( .. ) { .. }
+XPT subprotosigna " sub :prototype\( .. ) \( .. ) { .. }
 XSET arg*|post=ExpandIfNotEmpty(', ', 'arg*')
 sub `fun_name^ :prototype(`proto^) (`$SParg^`arg*^`$SParg^)`$BRfun^{
 	`cursor^
 }
 
-XPT asub " sub {}
+XPT subanony " sub { .. }
 sub {
 	`cursor^
 }
 
-XPT assub " sub ( .. ) { .. }
+XPT subanonysigna " sub \( .. ) { .. }
 XSET arg*|post=ExpandIfNotEmpty(', ', 'arg*')
 sub (`arg*^) {
 	`cursor^
 }
 
-XPT proto " sub .. ();
+XPT proto " sub .. \();
 sub `fun_name^ (`proto^);
 
-XPT unless " unless ( .. ) { .. }
+XPT unless " unless \( .. ) { .. }
 unless`$SPcmd^(`$SParg^`cond^`$SParg^)`$BRif^{
 	`cursor^
 }
@@ -122,7 +122,7 @@ finally`$BRif^{
 	`cursor^
 }
 
-XPT try wrap=risky " try ( .. ) { .. } ...
+XPT try wrap=risky " try \( .. ) { .. } ...
 try`$SPcmd^(`$SParg^`cond^`$SParg^)`$BRif^{
 	`risky^
 }`
@@ -136,7 +136,7 @@ defer`$BRif^{
 	`cursor^
 }
 
-XPT block " d{ .. }
+XPT block " { .. }
 {
 	`cursor^
 }
@@ -190,19 +190,19 @@ while`$SPcmd^(`$SParg^my $`line^`$SPop^=`$SPop^<`STDIN^>`$SParg^)`$BRloop^{
 }
 `continue...{{^`Include:_continue^`}}^
 
-XPT foreachx " foreach my .. ( .. ) { .. }
+XPT foreachx " foreach my .. \( .. ) { .. }
 foreach`$SPcmd^my $`var^ (`$SParg^`list^`$SParg^)`$BRloop^{
 	`cursor^
 }
 `continue...{{^`Include:_continue^`}}^
 
-XPT foreachi " foreach my .. ( .. ) { .. }
+XPT foreachi " foreach my .. \( .. ) { .. }
 foreach`$SPcmd^my (`$SParg^$`var^, $`var2^`$SParg^) (`$SParg^indexed `list^`$SParg^)`$BRloop^{
 	`cursor^
 }
 `continue...{{^`Include:_continue^`}}^
 
-XPT foreachy " foreach ( .. ) { .. } 
+XPT foreachy " foreach \( .. ) { .. } 
 foreach`$SPcmd^(`$SParg^`list^`$SParg^)`$BRloop^{
 	`cursor^
 }
@@ -234,10 +234,10 @@ XSET elts|pre=Echo('')
 XSET elts=c_printf_elts( R( 'pattern' ), ',' )
 "`pattern^"`elts^
 
-XPT printf	" printf\(...)
+XPT printf	" printf ...
 printf `:_printfElts:^
 
-XPT sprintf	" sprintf\(...)
+XPT sprintf	" sprintf ...
 sprintf `:_printfElts:^
 
 XPT _if hidden
@@ -245,10 +245,10 @@ if`$SPcmd^(`$SParg^`condition^`$SParg^)`$BRif^{
 	`cursor^
 }
 
-XPT if wrap " if ( .. ) { .. }
+XPT if wrap " if \( .. ) { .. }
 `Include:_if^
 
-XPT elif wrap " else if ( .. ) { .. }
+XPT elif wrap " else if \( .. ) { .. }
 els`Include:_if^
 
 XPT else wrap " else { ... }
@@ -256,7 +256,7 @@ else`$BRif^{
 	`cursor^
 }
 
-XPT ifee		" if (..) { .. } else if...
+XPT ifee		" if \( .. ) { .. } else if...
 `:_if:^` `else_if...{{^`$BRel^`Include:elif^``else_if...^`}}^
 `else...{{^`Include:else^`}}^
 
@@ -270,19 +270,19 @@ default {
     `cursor^
 }
 
-XPT when " when (..) { .. } ...
+XPT when " when \( .. ) { .. } ...
 `:_when:^` `when...{{^`$BRel^`Include:_when^``when...^`}}^
 `default...{{^`Include:_default^`}}^
 
-XPT given wrap=var " given ( .. ) { .. }
+XPT given wrap=var " given \( .. ) { .. }
 given`$SPcmd^(`$SParg^$`var^^`$SParg^)`$BRif^{
 	`cursor^
 }
 
-XPT use " use .. qw(...);
+XPT use " use .. qw\(...);
 use `module^ qw(`cursor^);
 
-XPT package " 
+XPT package " package
 package `className^;
 
 use strict;

--- a/ftplugin/perl/perl.xpt.vim
+++ b/ftplugin/perl/perl.xpt.vim
@@ -73,31 +73,15 @@ unless`$SPcmd^(`$SParg^`condition^`$SParg^)`$BRif^{{
 	`cursor^
 }}
 
-XPT sub " sub .. { .. }
-sub `fun_name^`$BRfun^{
+XPT sub " sub \( .. ) { .. }
+XSET arg*|post=ExpandInsideEdge(', ', '')
+sub `fun_name^`(`arg*`)^ {
 	`cursor^
 }
 
-XPT subsigna " sub .. \( .. ) { .. }
-XSET arg*|post=ExpandIfNotEmpty(', ', 'arg*')
-sub `fun_name^(`$SParg^`arg*^`$SParg^)`$BRfun^{
-	`cursor^
-}
-
-XPT subprotosigna " sub :prototype\( .. ) \( .. ) { .. }
+XPT subp " sub :prototype\( .. ) \( .. ) { .. }
 XSET arg*|post=ExpandIfNotEmpty(', ', 'arg*')
 sub `fun_name^ :prototype(`proto^) (`$SParg^`arg*^`$SParg^)`$BRfun^{
-	`cursor^
-}
-
-XPT subanony " sub { .. }
-sub {
-	`cursor^
-}
-
-XPT subanonysigna " sub \( .. ) { .. }
-XSET arg*|post=ExpandIfNotEmpty(', ', 'arg*')
-sub (`arg*^) {
 	`cursor^
 }
 
@@ -223,11 +207,14 @@ split m/`regex^/, `string^
 XPT join " split .., ..
 join `string^, `list^
 
-XPT open wrap=path " open .., .., ..
-open $`fh^, "`mode^", $`path^ or die "open: $!\n";
+XPT bar " __XXX__
+__`cursor^__
 
-XPT opendir wrap=path " open .., .., ..
-opendir $`dh^, "`mode^", $`path^ or die "opendir: $!\n";
+XPT open wrap=path " open .., .., ..
+open my $`fh^, "`mode^", $`path^ or die "open: $!\n";
+
+XPT opendir wrap=path " opendir .., .., ..
+opendir my $`dh^, $`path^ or die "opendir: $!\n";
 
 XPT _printfElts hidden 
 XSET elts|pre=Echo('')
@@ -300,5 +287,6 @@ sub new`$BRfun^{
 
 1;
 
+`__END__^
 ..XPT
 


### PR DESCRIPTION
To begin with, I'll thank you for this plugin, it is extremely powerful.

Most of the XP Perl templates were really outdated, None of the Perl programmers out there would want to use this style. So I gathered all good practices that are almost common amongst us the Perl programmers.

Perl has evolved and it is still evolving, newly added syntax

`defer {}`
`given { when {...} ... default {} }`
`try { ... } catch ($e) { ... } [ finally { ... } ]`
`sub [:prototype(...)] [:lvalue] [(...)] {...}`
`continue {}`

The list operators `map {...}`, `grep {...}`, `sort {...}`, `split ..,..` and `join .., ..` are too tied to Perl and deserve their place.

fixed the `if` construct, it was really buggy when used in nested contructs.